### PR TITLE
Add support for API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+
+### IntelliJ ###
+*.iml
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+sudo: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jGenderize
 
-Client for http://genderize.io web service.
+Client for [genderize.io](https://genderize.io/) web service.
 
 Simple Java extension to know the gender of a given first name.
 
@@ -13,6 +13,7 @@ System.out.println("John is: "+gender.getGender());
 System.out.println("is John male? " + gender.isMale());
 System.out.println("Who? " + gender.getName());
 ```
+
 What about "John" in Brazil? Localization support.
 
 ```java
@@ -21,15 +22,24 @@ NameGender gender = api.getGender("John", new Locale("pt", "BR"));
 System.out.println("John is: "+gender.getGender());
 System.out.println("is John male? " + gender.isMale());
 ```
+
 Lots of names? It is sorted.
 
 ```java
 Genderize api = GenderizeIoAPI.create();
 List<NameGender> genders = api.getGenders("Robson", "Marlise", "Gilmar");
 ```
-Does it works with l10n too? sure.
+
+Does it works with l10n too? Sure.
 
 ```java
 Genderize api = GenderizeIoAPI.create();
+List<NameGender> genders = api.getGenders(new String[] {"ted", "marshall", "lilly", "robin", "barney", "melissa"}, new Locale("en", "US"));
+```
+
+Have a paid API key from [store.genderize.io](https://store.genderize.io/)? Use it.
+
+```java
+Genderize api = GenderizeIoAPI.create("your_api_key_here");
 List<NameGender> genders = api.getGenders(new String[] {"ted", "marshall", "lilly", "robin", "barney", "melissa"}, new Locale("en", "US"));
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>irobson</groupId>
     <artifactId>jgenderize</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/github/irobson/jgenderize/GenderizeIoAPI.java
+++ b/src/main/java/com/github/irobson/jgenderize/GenderizeIoAPI.java
@@ -10,4 +10,12 @@ public class GenderizeIoAPI {
     public static Genderize create() {
         return new DefaultGenderize();
     }
+
+    /**
+     * @param apiKey Genderize.io API key.
+     * @return A client instance that can make more queries than one without a key.
+     */
+    public static Genderize create(String apiKey) {
+        return new DefaultGenderize(apiKey);
+    }
 }

--- a/src/main/java/com/github/irobson/jgenderize/client/DefaultGenderize.java
+++ b/src/main/java/com/github/irobson/jgenderize/client/DefaultGenderize.java
@@ -2,32 +2,49 @@ package com.github.irobson.jgenderize.client;
 
 import com.github.irobson.jgenderize.model.NameGender;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 
 public class DefaultGenderize implements Genderize, Serializable {
 
-    private final Client client = ClientBuilder.newBuilder().newClient();
+    private final Client client = ClientBuilder.newClient();
     
     private static final String GENDERIZE_IO_API_URL = "https://api.genderize.io/";
 
+    private static final GenericType<List<NameGender>> NAME_GENDER_LIST_TYPE
+            = new GenericType<List<NameGender>>() {};
+
+    /**
+     * May be null if not using an API key.
+     */
+    private final String apiKey;
+
+    public DefaultGenderize() {
+        this.apiKey = null;
+    }
+
+    /**
+     * @param apiKey Genderize.io API key.
+     */
+    public DefaultGenderize(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
     public NameGender getGender(String name, Locale locale) {
-        WebTarget target = client.target(GENDERIZE_IO_API_URL).queryParam("name", name);
-        if (locale != null) {
-            target = target.queryParam("country_id", locale.getCountry());
-            target = target.queryParam("language_id", locale.getLanguage());
-        }
-        return target.request(MediaType.APPLICATION_JSON_TYPE).get(NameGender.class);
+        return getGenders(new String[]{name}, locale).get(0);
     }
 
     public List<NameGender> getGenders(String[] names, Locale locale) {
-        GenericType<List<NameGender>> genericType = new GenericType<List<NameGender>>() {
-        };
+        if (names.length == 0) {
+            return Collections.emptyList();
+        }
 
         WebTarget target = client.target(GENDERIZE_IO_API_URL);
         for (int i = 0; i < names.length; i++) {
@@ -37,7 +54,18 @@ public class DefaultGenderize implements Genderize, Serializable {
             target = target.queryParam("country_id", locale.getCountry());
             target = target.queryParam("language_id", locale.getLanguage());
         }
-        return target.request(MediaType.APPLICATION_JSON_TYPE).get(genericType);
+        if (apiKey != null) {
+            target = target.queryParam("apikey", apiKey);
+        }
+        Invocation.Builder builder = target.request(MediaType.APPLICATION_JSON_TYPE);
+
+        if (names.length == 1) {
+            // Response format is different if requesting only one name.
+            NameGender nameGender = builder.get(NameGender.class);
+            return Collections.singletonList(nameGender);
+        }
+
+        return builder.get(NAME_GENDER_LIST_TYPE);
     }
 
     public NameGender getGender(String name) {

--- a/src/test/java/com/github/irobson/jgenderize/GenderizeIoAPITest.java
+++ b/src/test/java/com/github/irobson/jgenderize/GenderizeIoAPITest.java
@@ -61,4 +61,11 @@ public class GenderizeIoAPITest {
         Assert.assertEquals(1, genders.size());
         Assert.assertTrue(genders.get(0).isMale());
     }
+
+    @Test
+    public void testGetSingleNameUnknownGender() {
+        NameGender gender = GenderizeIoAPI.create().getGender("Thunderhorse");
+        Assert.assertFalse(gender.isFemale());
+        Assert.assertFalse(gender.isMale());
+    }
 }

--- a/src/test/java/com/github/irobson/jgenderize/GenderizeIoAPITest.java
+++ b/src/test/java/com/github/irobson/jgenderize/GenderizeIoAPITest.java
@@ -4,6 +4,7 @@ import com.github.irobson.jgenderize.client.Genderize;
 import com.github.irobson.jgenderize.model.NameGender;
 import java.util.List;
 import java.util.Locale;
+import javax.ws.rs.NotAuthorizedException;
 import junit.framework.Assert;
 import org.junit.Test;
 
@@ -43,4 +44,21 @@ public class GenderizeIoAPITest {
         Assert.assertTrue(genders.get(2).isFemale());
     }
 
+    @Test(expected=NotAuthorizedException.class)
+    public void testGetSingleNameBadAPIKey() {
+        GenderizeIoAPI.create("invalid_api_key").getGender("Kim");
+    }
+
+    @Test
+    public void testGetNoNames() {
+        List<NameGender> genders = GenderizeIoAPI.create().getGenders();
+        Assert.assertEquals(0, genders.size());
+    }
+
+    @Test
+    public void testGetSingleNameGenderWithMultiMethod() {
+        List<NameGender> genders = GenderizeIoAPI.create().getGenders("Robson");
+        Assert.assertEquals(1, genders.size());
+        Assert.assertTrue(genders.get(0).isMale());
+    }
 }


### PR DESCRIPTION
This lets jGenderize use paid API keys from store.genderize.io for high-rate commercial applications. It also contains a few bug fixes.
- new DefaultGenderize constructor and GenderizeIoAPI methods for creating clients with API keys
- simplified DefaultGenderize slightly
- fixed case where the list of names methods were used to request 0 or 1 name
- added integration tests
- updated version to 1.3 (still backwards compatible with 1.2)
- added .travis.yml for Travis CI support
- updated readme with examples for API key
